### PR TITLE
Automatically detect board size from SGF SZ property

### DIFF
--- a/README.en-US.md
+++ b/README.en-US.md
@@ -105,6 +105,8 @@ analysis:
   rules: 'tromp-taylor'
   # If input SGF/GIB has no komi field (KM), then uses below.
   komi: 7.5
+  # If input SGF has a valid SZ property, it overrides these board sizes.
+  # These values are used only as fallback when board size is unknown.
   boardXSize: 19
   boardYSize: 19
   # Maximum number of root visits.
@@ -115,6 +117,11 @@ sgf:
   # SGF can put good/bad/hotspot labels on moves for coloring game tree.
   # ......
 ```
+
+When the input SGF has a valid `SZ` property, `analyze-sgf` uses it for the
+KataGo analysis query `boardXSize` and `boardYSize`. The configured
+`boardXSize` and `boardYSize` values are used only as fallback when the board
+size is unknown.
 
 Now, run `analyze-sgf` with SGF/GIB files, for example, `shin-vs-lian.sgf`,
 the simple analysis result will be printed out, and a file

--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ analysis:
   rules: 'tromp-taylor'
   # If input SGF/GIB has no komi field (KM), then uses below.
   komi: 7.5
+  # If input SGF has a valid SZ property, it overrides these board sizes.
+  # These values are used only as fallback when board size is unknown.
   boardXSize: 19
   boardYSize: 19
   # Maximum number of root visits.
@@ -108,6 +110,10 @@ sgf:
   # SGF can put good/bad/hotspot labels on moves for coloring game tree.
   # ......
 ```
+
+입력 SGF에 `SZ` 속성이 있으면 `analyze-sgf`는 그 값을 카타고 분석 요청의
+`boardXSize`와 `boardYSize`로 사용합니다. 설정 파일의 `boardXSize`와
+`boardYSize`는 SGF에서 보드 크기를 알 수 없을 때만 기본값으로 사용됩니다.
 
 이제 기보 파일, 가령 `신진서-렌샤오.sgf`로 `analyze-sgf`를 실행하면 간단한 분석 결과가
 출력되고 `신진서-렌샤오-analyzed.sgf`라는 파일이 생깁니다.

--- a/src/analyze-sgf.yml
+++ b/src/analyze-sgf.yml
@@ -15,6 +15,8 @@ analysis:
   rules: "tromp-taylor"
   # If input SGF/GIB has no komi field (KM), then uses below.
   komi: 7.5
+  # If input SGF has a valid SZ property, it overrides these board sizes.
+  # These values are used only as fallback when board size is unknown.
   boardXSize: 19
   boardYSize: 19
   # Maximum number of root visits.

--- a/src/gametree.js
+++ b/src/gametree.js
@@ -15,9 +15,12 @@ const GameReport = require('./game-report');
 class GameTree {
   constructor(sgf, katagoResponses, opts) {
     const rs = sgfconv.rootAndSeqFromSGF(sgf);
+    const boardSize = sgfconv.boardSizeFromRoot(rs.root);
 
-    this.sz = rs.root.SZ ? parseInt(rs.root.SZ[0], 10) : 0;
-    this.opts = opts;
+    this.sz = boardSize ? Math.min(boardSize.x, boardSize.y) : 0;
+    this.opts = boardSize
+      ? { ...opts, boardXSize: boardSize.x, boardYSize: boardSize.y }
+      : opts;
 
     // Gets root node and sequence from SGF.
     this.root = rs.root;
@@ -67,8 +70,8 @@ function setWinrateAndVariatons(that, katagoResponses, pls) {
   const responses = splitResponses(that, katagoResponses);
   // Real `turnNumber` considering previous passing moves is
   // `realTurnNumbersMap[turnNumber]`.
-  const realTurnNumbers = sgfconv.hasPassMoves(that.seq)
-    ? katagoconv.makeRealTurnNumbersMap(that.seq)
+  const realTurnNumbers = sgfconv.hasPassMoves(that.seq, that.sz)
+    ? katagoconv.makeRealTurnNumbersMap(that.seq, that.sz)
     : undefined;
   // Notice that:
   // * responses.length === nodes.length + 1

--- a/src/katagoconv.js
+++ b/src/katagoconv.js
@@ -49,12 +49,14 @@ const mergeKataGoResponses = (original, revisited, turns) =>
 // Pass moves are not included in KataGo analysis. So we need to convert
 // KataGo turnNumbers to real turnNumbers considering previous passing moves.
 // Real `turnNumber` is `realTurnNumbersMap[turnNumber]`.
-const makeRealTurnNumbersMap = (seq) =>
+const makeRealTurnNumbersMap = (seq, sz = 19) =>
   [0].concat(
     seq
       .split(';')
       .filter((v) => v)
-      .map((move, index) => (sgfconv.isRegularMove(move) ? index + 1 : -1))
+      .map((move, index) =>
+        sgfconv.isRegularMove(move, sz) ? index + 1 : -1,
+      )
       .filter((v) => v !== -1),
   );
 
@@ -92,16 +94,21 @@ function sgfToKataGoAnalysisQuery(sgf, analysisOpts) {
 
   if (rs.root.KM) query.komi = parseFloat(rs.root.KM[0]);
   if (rs.root.PL) [query.initialPlayer] = rs.root.PL;
-  const sz = rs.root.SZ ? parseInt(rs.root.SZ[0], 10) : 0;
+  const boardSize = sgfconv.boardSizeFromRoot(rs.root);
+  const sz = boardSize ? Math.min(boardSize.x, boardSize.y) : 0;
 
   query.id = `9beach-${Date.now()}`;
+  if (boardSize) {
+    query.boardXSize = boardSize.x;
+    query.boardYSize = boardSize.y;
+  }
   query.initialStones = initialStonesFromRoot(rs.root);
   query.moves = seqToKataGoMoves(rs.seq, sz);
 
   if (!query.analyzeTurns) {
     query.analyzeTurns = [...Array(query.moves.length + 1).keys()];
-  } else if (sgfconv.hasPassMoves(rs.seq)) {
-    const realTurnNumbers = makeRealTurnNumbersMap(rs.seq);
+  } else if (sgfconv.hasPassMoves(rs.seq, sz)) {
+    const realTurnNumbers = makeRealTurnNumbersMap(rs.seq, sz);
     query.analyzeTurns = query.analyzeTurns
       .map((turn) => realTurnNumbers.indexOf(turn))
       .filter((turn) => turn !== -1);

--- a/src/sgfconv.js
+++ b/src/sgfconv.js
@@ -97,6 +97,15 @@ const correctSGFDialects = (sgf) =>
 
 const ofRoot = (root, key) => root[key] && root[key][0];
 
+function boardSizeFromRoot(root) {
+  if (!root.SZ || !root.SZ[0]) return undefined;
+
+  const size = root.SZ[0].split(':').map((v) => parseInt(v, 10));
+  if (size.some((v) => Number.isNaN(v) || v <= 0)) return undefined;
+
+  return { x: size[0], y: size[1] || size[0] };
+}
+
 // Makes file name from SGF.
 //
 // e.g., [제22회 농심배 13국, 2021-02-25] 커제 vs 신진서 (185수 흑불계승).sgf
@@ -210,6 +219,7 @@ module.exports = {
   removeTails,
   isPassMove,
   isRegularMove,
+  boardSizeFromRoot,
   rootAndSeqFromSGF,
   correctSGFDialects,
   prettyPathFromSGF,

--- a/test/gametree.test.js
+++ b/test/gametree.test.js
@@ -62,6 +62,17 @@ describe('GameTree', () => {
     );
   });
 
+  it('should format variations with board size from SGF.', () => {
+    const responses = `${JSON.stringify({
+      turnNumber: 0,
+      rootInfo: { winrate: 0.5, scoreLead: 0, visits: 10 },
+      moveInfos: [{ pv: ['A1'], winrate: 0.5, scoreLead: 0, visits: 10 }],
+    })}\n`;
+    const gametree = new GameTree('(;SZ[9];B[bb])', responses, sgfopts);
+
+    assert(gametree.getSGF().indexOf('1. A9') !== -1);
+  });
+
   it('should be expected values for "t-sabaki-1-default.sgf".', () => {
     sgfopts.maxVariationsForEachMove = 10;
     sgfopts.maxWinrateDropForGoodMove = 2;

--- a/test/katagoconv.test.js
+++ b/test/katagoconv.test.js
@@ -106,3 +106,41 @@ describe('makeRealTurnNumbersMap', () => {
     );
   });
 });
+
+describe('sgfToKataGoAnalysisQuery', () => {
+  it('should use board size from SGF.', () => {
+    const query9 = katagoconv.sgfToKataGoAnalysisQuery(
+      '(;SZ[9]KM[6.5];B[aa])',
+      { boardXSize: 19, boardYSize: 19 },
+    );
+    const query13 = katagoconv.sgfToKataGoAnalysisQuery(
+      '(;SZ[13]KM[6.5];B[aa])',
+      { boardXSize: 19, boardYSize: 19 },
+    );
+
+    assert.equal(query9.boardXSize, 9);
+    assert.equal(query9.boardYSize, 9);
+    assert.equal(query13.boardXSize, 13);
+    assert.equal(query13.boardYSize, 13);
+  });
+
+  it('should use rectangular board size from SGF.', () => {
+    const query = katagoconv.sgfToKataGoAnalysisQuery(
+      '(;SZ[13:9]KM[6.5];B[aa])',
+      { boardXSize: 19, boardYSize: 19 },
+    );
+
+    assert.equal(query.boardXSize, 13);
+    assert.equal(query.boardYSize, 9);
+  });
+
+  it('should keep configured board size without SZ.', () => {
+    const query = katagoconv.sgfToKataGoAnalysisQuery('(;KM[6.5];B[aa])', {
+      boardXSize: 13,
+      boardYSize: 13,
+    });
+
+    assert.equal(query.boardXSize, 13);
+    assert.equal(query.boardYSize, 13);
+  });
+});

--- a/test/sgfconv.test.js
+++ b/test/sgfconv.test.js
@@ -63,6 +63,36 @@ describe('iaToJ1/iaFromJ1', () => {
   });
 });
 
+describe('boardSizeFromRoot', () => {
+  it('should return square board size.', () => {
+    assert.deepEqual(sgfconv.boardSizeFromRoot({ SZ: ['9'] }), {
+      x: 9,
+      y: 9,
+    });
+    assert.deepEqual(sgfconv.boardSizeFromRoot({ SZ: ['13'] }), {
+      x: 13,
+      y: 13,
+    });
+    assert.deepEqual(sgfconv.boardSizeFromRoot({ SZ: ['19'] }), {
+      x: 19,
+      y: 19,
+    });
+  });
+
+  it('should return rectangular board size.', () => {
+    assert.deepEqual(sgfconv.boardSizeFromRoot({ SZ: ['13:9'] }), {
+      x: 13,
+      y: 9,
+    });
+  });
+
+  it('should ignore missing or invalid board size.', () => {
+    assert.equal(sgfconv.boardSizeFromRoot({}), undefined);
+    assert.equal(sgfconv.boardSizeFromRoot({ SZ: ['x'] }), undefined);
+    assert.equal(sgfconv.boardSizeFromRoot({ SZ: ['0'] }), undefined);
+  });
+});
+
 describe('toGoodNode/toBadNode/toBadHotSpot', () => {
   const seq = '(;W[po];B[hm])';
   it('should be expected values.', () => {


### PR DESCRIPTION
## Summary

Automatically set KataGo's `boardXSize` and `boardYSize` from the SGF root
`SZ` property.

This allows 9x9, 13x13, 19x19, and rectangular boards to be analyzed without
manually overriding the board dimensions for each file.

## Behavior

- `SZ[9]` sets a 9x9 board
- `SZ[13]` sets a 13x13 board
- `SZ[19]` sets a 19x19 board
- `SZ[13:9]` sets a 13x9 rectangular board
- Missing or invalid `SZ` values preserve the configured board dimensions
- Explicit command-line board-size overrides remain supported

## Changes

- Parse square and rectangular SGF board sizes
- Apply detected dimensions to KataGo analysis queries
- Use the detected board height when formatting variations
- Add unit tests for valid, invalid, missing, and rectangular sizes
- Document automatic board-size detection

## Tests

- `npm test`
- `npm run lint`